### PR TITLE
fix bug for convert_ids_to_tokens

### DIFF
--- a/qlora/qlora.py
+++ b/qlora/qlora.py
@@ -366,8 +366,7 @@ def get_accelerate_model(args, checkpoint_dir):
             tokenizer=tokenizer,
             model=model,
         )
-    # if 'llama' in args.model_name_or_path or isinstance(tokenizer, LlamaTokenizer):
-    if ('llama' in args.model_name_or_path or isinstance(tokenizer, LlamaTokenizer)) and args.tokenizer_name != "novelai/nerdstash-tokenizer-v1":
+    if 'llama' in args.model_name_or_path or isinstance(tokenizer, LlamaTokenizer):
         # LLaMA tokenizer may not have correct special tokens set.
         # Check and add them if missing to prevent them from being parsed into different tokens.
         # Note that these are present in the vocabulary.
@@ -376,10 +375,13 @@ def get_accelerate_model(args, checkpoint_dir):
         tokenizer.add_special_tokens({
                 "eos_token": tokenizer.convert_ids_to_tokens(model.config.eos_token_id),
                 "bos_token": tokenizer.convert_ids_to_tokens(model.config.bos_token_id),
+        })
+        if model.config.pad_token_id is not None and tokenizer.pad_token_id is not None:
+            tokenizer.add_special_tokens({
                 "unk_token": tokenizer.convert_ids_to_tokens(
                     model.config.pad_token_id if model.config.pad_token_id != -1 else tokenizer.pad_token_id
                 ),
-        })
+            })
     
     if not args.full_finetune:
         model = prepare_model_for_kbit_training(model, use_gradient_checkpointing=args.gradient_checkpointing)


### PR DESCRIPTION
`stabilityai/japanese-stablelm-base-alpha-7b` ロード時の以下のエラーへの対応

```bash
/usr/local/lib/python3.10/dist-packages/transformers/models/auto/auto_factory.py:472: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers.
  warnings.warn(
You passed `quantization_config` to `from_pretrained` but the model you're loading already has a `quantization_config` attribute. The `quantization_config` attribute will be overwritten with the one you passed to `from_pretrained`.
/usr/local/lib/python3.10/dist-packages/transformers/utils/hub.py:374: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers.
  warnings.warn(
/usr/local/lib/python3.10/dist-packages/transformers/models/auto/tokenization_auto.py:655: FutureWarning: The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers.
  warnings.warn(
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Adding special tokens.
Traceback (most recent call last):
  File "/content/drive/MyDrive/llama2_qlora/qlora_ja/qlora/qlora.py", line 860, in <module>
    train()
  File "/content/drive/MyDrive/llama2_qlora/qlora_ja/qlora/qlora.py", line 717, in train
    model, tokenizer = get_accelerate_model(args, checkpoint_dir)
  File "/content/drive/MyDrive/llama2_qlora/qlora_ja/qlora/qlora.py", line 379, in get_accelerate_model
    "unk_token": tokenizer.convert_ids_to_tokens(
  File "/usr/local/lib/python3.10/dist-packages/transformers/tokenization_utils.py", line 964, in convert_ids_to_tokens
    for index in ids:
TypeError: 'NoneType' object is not iterable
```