### PR TITLE
fix bug for  GPTNeoXTokenizer does not exist

### DIFF
--- a/qlora/qlora.py
+++ b/qlora/qlora.py
@@ -83,6 +83,9 @@ class ModelArguments:
     tokenizer_name: Optional[str] = field(
         default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
     )
+    use_fast_tokenizer: Optional[bool] = field(
+        default=False,
+    )
     variant: Optional[str] = field(
         default=None
     )
@@ -355,7 +358,7 @@ def get_accelerate_model(args, checkpoint_dir):
         args.tokenizer_name if args.tokenizer_name else args.model_name_or_path,
         cache_dir=args.cache_dir,
         padding_side="right",
-        use_fast=False, # Fast tokenizer giving issues.
+        use_fast=args.use_fast_tokenizer, # Fast tokenizer giving issues.
         tokenizer_type='llama' if 'llama' in args.model_name_or_path else None, # Needed for HF name change
         trust_remote_code=args.trust_remote_code,
         use_auth_token=args.use_auth_token,


### PR DESCRIPTION
`studio-ousia/open-calm-7b-8bit` ロード時の以下のエラーへの対応

```bash
Traceback (most recent call last):
  File "/content/drive/MyDrive/llama2_qlora/qlora_ja/qlora/qlora.py", line 862, in <module>
    train()
  File "/content/drive/MyDrive/llama2_qlora/qlora_ja/qlora/qlora.py", line 719, in train
    model, tokenizer = get_accelerate_model(args, checkpoint_dir)
  File "/content/drive/MyDrive/llama2_qlora/qlora_ja/qlora/qlora.py", line 354, in get_accelerate_model
    tokenizer = AutoTokenizer.from_pretrained(
  File "/usr/local/lib/python3.10/dist-packages/transformers/models/auto/tokenization_auto.py", line 748, in from_pretrained
    raise ValueError(
ValueError: Tokenizer class GPTNeoXTokenizer does not exist or is not currently imported.
```